### PR TITLE
Adding an extra sanity check

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -71,8 +71,8 @@ def main_call(msg, text=None):
         news_parser = textparser.Parser(text)
         ready_news = news_parser()
         if type(ready_news) is tuple:
-            bot.send_message(msg.chat.id, ready_news[0])
             bot.send_message(msg.chat.id, ready_news[1])
+            bot.send_message(msg.chat.id, ready_news[0])
         else:
             bot.send_message(msg.chat.id, ready_news)
     if getlog == True:

--- a/ifaxbotcovid/config/settings.py
+++ b/ifaxbotcovid/config/settings.py
@@ -1,2 +1,9 @@
 # TOKEN for testing usage
 TOKEN = ''
+
+# reference values for checking purposes
+base_vars = {
+    'russia_total_cases' : '4957755',
+    'russia_total_deaths' : '116574',
+    'russia_total_recovered' : '4572226'
+}

--- a/tests/unit_tests/test_textparser.py
+++ b/tests/unit_tests/test_textparser.py
@@ -2,7 +2,6 @@
 Tests textparser.py functionality along with its dependencies
 '''
 
-from os import truncate
 from pathlib import Path
 
 from ifaxbotcovid import textparser
@@ -128,3 +127,32 @@ class TestUnitParser:
                     failed_keys.append(key)
             assert errors == 0,\
                 f'Expected values did not found. Failed keys: {str(failed_keys)}'
+        
+        def test_fool_check(self):
+            
+            good_dct = {'russia_new_cases' : '7920',
+                'russia_current_pace' : '+0,16%',
+                'russia_new_deaths' : '390',
+                'russia_new_recovered' : '9 561',
+                'russia_total_cases' : '4960000',
+                'moscow_new_cases' : '2096',
+                'moscow_new_deaths' : '61',
+                'moscow_new_recovered' : '2663',
+                'date_dateline' : '7 июня',
+                'date_day' : 'в понедельник',
+                'golden_cite' : 'Большая и длинная цитата',
+                'russia_total_deaths' : '116600',
+                'russia_total_recovered' : '4600000',
+                'russia_active' : '99999',
+                }
+
+            bad_dct = good_dct.copy()
+            bad_dct['russia_total_cases'] = '4957740'
+            bad_dct['russia_total_deaths'] = '116560'
+            bad_dct['russia_total_recovered'] = '72226'
+
+            assert TestUnitParser.parser.fool_check(good_dct) == False,\
+                f"Fool_check method have found a mistake where there shouldn't be one"
+            assert TestUnitParser.parser.fool_check(bad_dct),\
+                f"Fool_check method failed to detect error"
+


### PR DESCRIPTION
Copy-pasting raw press-release can lead to mistakes. A lost digit in the copied text passes silently as a valid input without any message to the user.

Thus a new feature added to warn the user about suspicious input in key variables (such as amount of total COVID-19 cases, deaths and recovered persons). If this variables are smaller then reference values, user will get a special warning.